### PR TITLE
Fix some variable names

### DIFF
--- a/src/Symmetry.jl
+++ b/src/Symmetry.jl
@@ -89,13 +89,6 @@ function symmetrytype(trace, determinant)
 end
 symmetrytype(op::PointSymmetry) = symmetrytype(tr(op), det(op))
 
-# These are helper methods and should not be exported!
-_numbers(a::AbstractVector{<:Integer}) = convert(Vector{Int64}, a)
-function _numbers(a::AbstractVector{T}) where {T}
-    d = Dict(value => key for (key, value) in pairs(unique(a)))
-    return Int64[d[v] for v in a]
-end
-
 """
     SeitzOperator(m::AbstractMatrix)
 

--- a/src/lattice.jl
+++ b/src/lattice.jl
@@ -87,7 +87,7 @@ struct Lattice{T}
     data::SMatrix{3,3,T,9}
 end
 Lattice(m::AbstractMatrix) = Lattice(SMatrix{3,3}(m))
-Lattice(a::AbstractVector, b::AbstractVector, c::AbstractVector) = Lattice(hcat(a, b, c))
+Lattice(𝐚::AbstractVector, 𝐛::AbstractVector, 𝐜::AbstractVector) = Lattice(hcat(𝐚, 𝐛, 𝐜))
 Lattice(x::Lattice) = x
 function Lattice(a, b, c, α, β, γ)
     # From https://github.com/LaurentRDC/crystals/blob/dbb3a92/crystals/lattice.py#L321-L354
@@ -126,11 +126,11 @@ function crystalsystem(a, b, c, α, β, γ)
     end
 end
 function crystalsystem(lattice::Lattice)
-    v1, v2, v3 = basis_vectors(lattice)
-    a, b, c = norm(v1), norm(v2), norm(v3)
-    γ = acos(dot(v1, v2) / a / b)
-    β = acos(dot(v2, v3) / b / c)
-    α = acos(dot(v1, v3) / a / c)
+    𝐚, 𝐛, 𝐜 = basis_vectors(lattice)
+    a, b, c = norm(𝐚), norm(𝐛), norm(𝐜)
+    γ = acos(dot(𝐚, 𝐛) / a / b)
+    β = acos(dot(𝐛, 𝐜) / b / c)
+    α = acos(dot(𝐚, 𝐜) / a / c)
     return crystalsystem(a, b, c, α, β, γ)
 end
 

--- a/src/metric.jl
+++ b/src/metric.jl
@@ -12,19 +12,19 @@ function MetricTensor(𝐚::AbstractVector, 𝐛::AbstractVector, 𝐜::Abstract
     return MetricTensor([dot(vecs[i], vecs[j]) for i in 1:3, j in 1:3])
 end
 function MetricTensor(a, b, c, α, β, γ)
-    g12 = a * b * cos(γ)
-    g13 = a * c * cos(β)
-    g23 = b * c * cos(α)
-    return MetricTensor(SHermitianCompact(SVector(a^2, g12, g13, b^2, g23, c^2)))
+    g₁₂ = a * b * cos(γ)
+    g₁₃ = a * c * cos(β)
+    g₂₃ = b * c * cos(α)
+    return MetricTensor(SHermitianCompact(SVector(a^2, g₁₂, g₁₃, b^2, g₂₃, c^2)))
 end
 
 Lattice(g::MetricTensor) = Lattice(cellparameters(g))
 
 function cellparameters(g::MetricTensor)
     data = g.data
-    a2, b2, c2, ab, ac, bc =
+    a², b², c², ab, ac, bc =
         data[1, 1], data[2, 2], data[3, 3], data[1, 2], data[1, 3], data[2, 3]
-    a, b, c = map(sqrt, (a2, b2, c2))
+    a, b, c = map(sqrt, (a², b², c²))
     γ, β, α = acos(ab / (a * b)), acos(ac / (a * c)), acos(bc / (b * c))
     return a, b, c, α, β, γ
 end
@@ -41,7 +41,7 @@ interplanar_spacing(𝐚::AbstractVector, g::MetricTensor) = 1 / norm(𝐚, g)
 
 Base.size(::MetricTensor) = (3, 3)
 
-Base.getindex(A::MetricTensor, I::Vararg{Int}) = getindex(A.data, I...)
+Base.getindex(g::MetricTensor, I::Vararg{Int}) = getindex(g.data, I...)
 
 Base.inv(g::MetricTensor) = MetricTensor(inv(g.data))
 

--- a/src/metric.jl
+++ b/src/metric.jl
@@ -7,8 +7,8 @@ struct MetricTensor{T} <: AbstractMatrix{T}
     data::SHermitianCompact{3,T,6}
 end
 MetricTensor(m::AbstractMatrix) = MetricTensor(SHermitianCompact{3}(m))
-function MetricTensor(v1::AbstractVector, v2::AbstractVector, v3::AbstractVector)
-    vecs = (v1, v2, v3)
+function MetricTensor(𝐚::AbstractVector, 𝐛::AbstractVector, 𝐜::AbstractVector)
+    vecs = (𝐚, 𝐛, 𝐜)
     return MetricTensor([dot(vecs[i], vecs[j]) for i in 1:3, j in 1:3])
 end
 function MetricTensor(a, b, c, α, β, γ)
@@ -29,15 +29,15 @@ function cellparameters(g::MetricTensor)
     return a, b, c, α, β, γ
 end
 
-directioncosine(a::AbstractVector, g::MetricTensor, b::AbstractVector) =
-    dot(a, g, b) / (norm(a, g) * norm(b, g))
+directioncosine(𝐚::AbstractVector, g::MetricTensor, 𝐛::AbstractVector) =
+    dot(𝐚, g, 𝐛) / (norm(𝐚, g) * norm(𝐛, g))
 
-directionangle(a::AbstractVector, g::MetricTensor, b::AbstractVector) =
-    acos(directioncosine(a, g, b))
+directionangle(𝐚::AbstractVector, g::MetricTensor, 𝐛::AbstractVector) =
+    acos(directioncosine(𝐚, g, 𝐛))
 
-distance(a::AbstractVector, g::MetricTensor, b::AbstractVector) = norm(b - a, g)
+distance(𝐚::AbstractVector, g::MetricTensor, 𝐛::AbstractVector) = norm(𝐛 - 𝐚, g)
 
-interplanar_spacing(a::AbstractVector, g::MetricTensor) = 1 / norm(a, g)
+interplanar_spacing(𝐚::AbstractVector, g::MetricTensor) = 1 / norm(𝐚, g)
 
 Base.size(::MetricTensor) = (3, 3)
 
@@ -45,5 +45,5 @@ Base.getindex(A::MetricTensor, I::Vararg{Int}) = getindex(A.data, I...)
 
 Base.inv(g::MetricTensor) = MetricTensor(inv(g.data))
 
-dot(a::AbstractVector, g::MetricTensor, b::AbstractVector) = a' * g.data * b
-norm(a::AbstractVector, g::MetricTensor) = sqrt(dot(a, g, a))
+dot(𝐚::AbstractVector, g::MetricTensor, 𝐛::AbstractVector) = 𝐚' * g.data * 𝐛
+norm(𝐚::AbstractVector, g::MetricTensor) = sqrt(dot(𝐚, g, 𝐚))

--- a/src/reciprocal.jl
+++ b/src/reciprocal.jl
@@ -6,8 +6,8 @@ export ReciprocalPoint, reciprocal_mesh, coordinates, weights
 
 function reciprocal(lattice::Lattice)
     volume = cellvolume(lattice)
-    a1, a2, a3 = basis_vectors(lattice)
-    return 1 / volume * [cross(a2, a3) cross(a3, a1) cross(a1, a2)]
+    𝐚, 𝐛, 𝐜 = basis_vectors(lattice)
+    return 1 / volume * [cross(𝐛, 𝐜) cross(𝐜, 𝐚) cross(𝐚, 𝐛)]
 end
 
 """


### PR DESCRIPTION
Use bold `a`, `b`, `c` to represent basis vectors