### PR TITLE
Implement iteration & indexing interfaces for `ChangeOfBasis` 4 types

### DIFF
--- a/src/lattice.jl
+++ b/src/lattice.jl
@@ -154,7 +154,23 @@ function supercell(cell::Lattice, expansion::AbstractVector{<:Integer})
 end
 function supercell(cell::Cell, expansion) end
 
-Base.size(::Lattice) = (3, 3)
-Base.length(::Lattice) = 9  # Number of elements
-Base.getindex(A::Lattice, i::Integer, j::Integer) = getindex(A.data, i, j)
+Base.iterate(lattice::Lattice) = iterate(lattice.data)
+Base.iterate(lattice::Lattice, state) = iterate(lattice.data, state)
+
 Base.eltype(::Lattice{T}) where {T} = T
+
+Base.length(::Lattice) = 9
+
+Base.size(::Lattice) = (3, 3)
+Base.size(::Lattice, dim::Integer) = dim <= 2 ? 3 : 1
+
+Base.IteratorSize(::Type{<:Lattice}) = Base.HasShape{2}()
+
+Base.axes(lattice::Lattice, dim::Integer) = axes(lattice.data, dim)
+
+Base.getindex(lattice::Lattice, i) = getindex(lattice.data, i)
+Base.getindex(lattice::Lattice, I::Vararg) = getindex(lattice.data, I...)
+
+Base.firstindex(::Lattice) = 1
+
+Base.lastindex(::Lattice) = 9

--- a/src/metric.jl
+++ b/src/metric.jl
@@ -41,7 +41,9 @@ interplanar_spacing(𝐚::AbstractVector, g::MetricTensor) = 1 / norm(𝐚, g)
 
 Base.size(::MetricTensor) = (3, 3)
 
-Base.getindex(g::MetricTensor, I::Vararg{Int}) = getindex(g.data, I...)
+Base.IndexStyle(::Type{<:MetricTensor}) = IndexLinear()
+
+Base.getindex(g::MetricTensor, I::Vararg) = getindex(g.data, I...)
 
 Base.inv(g::MetricTensor) = MetricTensor(inv(g.data))
 

--- a/src/miller.jl
+++ b/src/miller.jl
@@ -58,7 +58,9 @@ end
 Base.size(::Miller) = (3,)
 Base.size(::MillerBravais) = (4,)
 
-Base.getindex(A::Union{Miller,MillerBravais}, i::Int) = getindex(A.data, i)
+Base.IndexStyle(::Type{<:Union{Miller,MillerBravais}}) = IndexLinear()
+
+Base.getindex(x::Union{Miller,MillerBravais}, i::Integer) = getindex(x.data, i)
 
 Base.convert(::Type{T}, x::T) where {T<:INDICES} = x
 Base.convert(::Type{Miller{T}}, mb::MillerBravais{T}) where {T<:RealSpace} =

--- a/src/transform.jl
+++ b/src/transform.jl
@@ -127,15 +127,35 @@ Base.:∘(x::PrimitiveFromStandardized, y::StandardizedFromPrimitive) = ∘(y, x
 Base.:∘(x::StandardizedFromPrimitive, y::PrimitiveFromStandardized) =
     x.tf * y.tf ≈ I ? IdentityTransformation() : error("undefined!")
 
-function Base.show(
-    io::IO,
-    x::Union{
-        CartesianFromFractional,
-        FractionalFromCartesian,
-        StandardizedFromPrimitive,
-        PrimitiveFromStandardized,
-    },
-)
+const ChangeOfBasis{T} = Union{
+    CartesianFromFractional{T},
+    FractionalFromCartesian{T},
+    StandardizedFromPrimitive{T},
+    PrimitiveFromStandardized{T},
+}
+Base.iterate(x::ChangeOfBasis) = iterate(x.tf)
+Base.iterate(x::ChangeOfBasis, state) = iterate(x.tf, state)
+
+Base.eltype(::Type{<:ChangeOfBasis{T}}) where {T} = T
+
+Base.length(::ChangeOfBasis) = 9
+
+Base.size(::ChangeOfBasis) = (3, 3)
+Base.size(::ChangeOfBasis, dim::Integer) = dim <= 2 ? 3 : 1
+
+Base.IteratorSize(::Type{<:ChangeOfBasis}) = Base.HasShape{2}()
+
+# Enables `firstindex(x, dim)` and `x[1, 2:end]` or `x[begin:2, 2]`
+Base.axes(x::ChangeOfBasis, dim::Integer) = axes(x.tf, dim)
+
+Base.getindex(x::ChangeOfBasis, i) = getindex(x.tf, i)
+Base.getindex(x::ChangeOfBasis, I::Vararg) = getindex(x.tf, I...)
+
+Base.firstindex(::ChangeOfBasis) = 1
+
+Base.lastindex(::ChangeOfBasis) = 9
+
+function Base.show(io::IO, x::ChangeOfBasis)
     if get(io, :compact, false)
         print(io, string(typeof(x)), '(')
         print(io, x.tf, ')')


### PR DESCRIPTION
- Implement iteration & indexing interfaces for `ChangeOfBasis` 4 types
- Fix iteration & indexing interfaces for `Lattice`
- Fix array interface for `MetricTensor`
- Fix array interface for `MillerBravais` & `MillerBravais`