### PR TITLE
Use sind, cosd, etc., instead of sin, cos, etc.

### DIFF
--- a/src/lattice.jl
+++ b/src/lattice.jl
@@ -93,11 +93,11 @@ function Lattice(a, b, c, α, β, γ)
     # From https://github.com/LaurentRDC/crystals/blob/dbb3a92/crystals/lattice.py#L321-L354
     v = cellvolume(1, 1, 1, α, β, γ)
     # reciprocal lattice
-    a_recip = sin(α) / (a * v)
-    csg = (cos(α) * cos(β) - cos(γ)) / (sin(α) * sin(β))
+    a_recip = sind(α) / (a * v)
+    csg = (cosd(α) * cosd(β) - cosd(γ)) / (sind(α) * sind(β))
     sg = sqrt(1 - csg^2)
-    a1 = [1 / a_recip, -csg / sg / a_recip, cos(β) * a]
-    a2 = [0, b * sin(α), b * cos(α)]
+    a1 = [1 / a_recip, -csg / sg / a_recip, cosd(β) * a]
+    a2 = [0, b * sind(α), b * cosd(α)]
     a3 = [0, 0, c]
     return Lattice(a1, a2, a3)
 end
@@ -128,7 +128,7 @@ function cellparameters(lattice::Lattice)
     𝐚, 𝐛, 𝐜 = basis_vectors(lattice)
     a, b, c = norm(𝐚), norm(𝐛), norm(𝐜)
     γ, β, α =
-        acos(dot(𝐚, 𝐛) / (a * b)), acos(dot(𝐚, 𝐜) / (a * c)), acos(dot(𝐛, 𝐜) / (b * c))
+        acosd(dot(𝐚, 𝐛) / (a * b)), acosd(dot(𝐚, 𝐜) / (a * c)), acosd(dot(𝐛, 𝐜) / (b * c))
     return a, b, c, α, β, γ
 end
 

--- a/src/metric.jl
+++ b/src/metric.jl
@@ -12,9 +12,9 @@ function MetricTensor(𝐚::AbstractVector, 𝐛::AbstractVector, 𝐜::Abstract
     return MetricTensor([dot(vᵢ, vⱼ) for vᵢ in vecs, vⱼ in vecs])
 end
 function MetricTensor(a, b, c, α, β, γ)
-    g₁₂ = a * b * cos(γ)
-    g₁₃ = a * c * cos(β)
-    g₂₃ = b * c * cos(α)
+    g₁₂ = a * b * cosd(γ)
+    g₁₃ = a * c * cosd(β)
+    g₂₃ = b * c * cosd(α)
     return MetricTensor(SHermitianCompact(SVector(a^2, g₁₂, g₁₃, b^2, g₂₃, c^2)))
 end
 
@@ -23,7 +23,7 @@ Lattice(g::MetricTensor) = Lattice(cellparameters(g))
 function cellparameters(g::MetricTensor)
     a², b², c², ab, ac, bc = g[1, 1], g[2, 2], g[3, 3], g[1, 2], g[1, 3], g[2, 3]
     a, b, c = map(sqrt, (a², b², c²))
-    γ, β, α = acos(ab / (a * b)), acos(ac / (a * c)), acos(bc / (b * c))
+    γ, β, α = acosd(ab / (a * b)), acosd(ac / (a * c)), acosd(bc / (b * c))
     return a, b, c, α, β, γ
 end
 
@@ -31,7 +31,7 @@ directioncosine(𝐚::AbstractVector, g::MetricTensor, 𝐛::AbstractVector) =
     dot(𝐚, g, 𝐛) / (norm(𝐚, g) * norm(𝐛, g))
 
 directionangle(𝐚::AbstractVector, g::MetricTensor, 𝐛::AbstractVector) =
-    acos(directioncosine(𝐚, g, 𝐛))
+    acosd(directioncosine(𝐚, g, 𝐛))
 
 distance(𝐚::AbstractVector, g::MetricTensor, 𝐛::AbstractVector) = norm(𝐛 - 𝐚, g)
 

--- a/src/transform.jl
+++ b/src/transform.jl
@@ -21,10 +21,10 @@ end
 CartesianFromFractional(lattice::Lattice) = CartesianFromFractional(lattice.data)
 function CartesianFromFractional(a, b, c, α, β, γ)
     Ω = cellvolume(a, b, c, α, β, γ)
-    b_sinγ, b_cosγ = b .* sincos(γ)
+    b_sinγ, b_cosγ = b .* (sind(γ), cosd(γ))
     return CartesianFromFractional(
         [
-            a b_cosγ c*cos(β)
+            a b_cosγ c*cosd(β)
             0 b_sinγ c*_auxiliary(α, β, γ)
             0 0 Ω/(a*b_sinγ)
         ],
@@ -33,10 +33,10 @@ end
 FractionalFromCartesian(lattice::Lattice) = FractionalFromCartesian(inv(lattice.data))
 function FractionalFromCartesian(a, b, c, α, β, γ)
     Ω = cellvolume(a, b, c, α, β, γ)
-    b_sinγ = b * sin(γ)
+    b_sinγ = b * sind(γ)
     return FractionalFromCartesian(
         [
-            1/a -cot(γ)/a -b*c*_auxiliary(β, α, γ)/Ω
+            1/a -cotd(γ)/a -b*c*_auxiliary(β, α, γ)/Ω
             0 1/b_sinγ -a*c*_auxiliary(α, β, γ)/Ω
             0 0 a*b_sinγ/Ω
         ],
@@ -46,7 +46,7 @@ const FractionalToCartesian = CartesianFromFractional
 const CartesianToFractional = FractionalFromCartesian
 
 # This is a helper function and should not be exported!
-_auxiliary(α, β, γ) = (cos(α) - cos(β) * cos(γ)) / sin(γ)
+_auxiliary(α, β, γ) = (cosd(α) - cosd(β) * cosd(γ)) / sind(γ)
 
 (x::Union{CartesianFromFractional,FractionalFromCartesian})(v) = x.tf * collect(v)
 

--- a/src/volume.jl
+++ b/src/volume.jl
@@ -4,7 +4,7 @@
 Calculates the cell volume from 6 cell parameters.
 """
 cellvolume(a, b, c, α, β, γ) =
-    a * b * c * sqrt(sin(α)^2 - cos(β)^2 - cos(γ)^2 + 2 * cos(α) * cos(β) * cos(γ))
+    a * b * c * sqrt(sind(α)^2 - cosd(β)^2 - cosd(γ)^2 + 2 * cosd(α) * cosd(β) * cosd(γ))
 """
     cellvolume(l::Lattice)
     cellvolume(c::Cell)

--- a/test/metric.jl
+++ b/test/metric.jl
@@ -23,7 +23,7 @@ end
 end
 
 @testset "Symbolic calculation" begin
-    a, b, c = symbols("a, b, c", positive = true)
-    @test MetricTensor(a, b, c, 90, 90, 120) ==
-          MetricTensor([a^2 -a^2/2 0; -a^2/2 a^2 0; 0 0 c^2])  # Primitive hexagonal
+    a, c = symbols("a, c", positive = true)
+    @test MetricTensor(a, a, c, 90, 90, 120) ==
+          MetricTensor([a^2 -0.5*a^2 0; -0.5*a^2 a^2 0; 0 0 c^2])  # Primitive hexagonal
 end

--- a/test/metric.jl
+++ b/test/metric.jl
@@ -2,21 +2,21 @@ using LinearAlgebra: dot, norm
 using SymPy: symbols
 
 @testset "Test length in a hexagonal lattice" begin
-    g = MetricTensor(1, 1, 2, pi / 2, pi / 2, 2pi / 3)  # Primitive hexagonal
+    g = MetricTensor(1, 1, 2, 90, 90, 120)  # Primitive hexagonal
     a = [1, 2, 1]
     @test dot(a, g, a) ≈ 7
     @test norm([1, 2, 1], g)^2 ≈ 7
 end
 
 @testset "Test distance between atoms in a hexagonal lattice" begin
-    g = MetricTensor(1, 1, 2, pi / 2, pi / 2, 2pi / 3)  # Primitive hexagonal
+    g = MetricTensor(1, 1, 2, 90, 90, 120)  # Primitive hexagonal
     a = [1, 1, 1]
     b = [1 // 3, 1 // 3, 1 // 2]
     @test distance(a, g, b)^2 == 13 / 9
 end
 
 @testset "Test direction cosine in a tetragonal lattice" begin
-    g = MetricTensor(2, 2, 3, pi / 2, pi / 2, pi / 2)  # Primitive tetragonal
+    g = MetricTensor(2, 2, 3, 90, 90, 90)  # Primitive tetragonal
     a = [1, 2, 1]
     b = [0, 0, 1]
     @test directioncosine(a, g, b)^2 ≈ 9 / 29
@@ -24,6 +24,6 @@ end
 
 @testset "Symbolic calculation" begin
     a, b, c = symbols("a, b, c", positive = true)
-    @test MetricTensor(a, b, c, pi / 2, pi / 2, 2pi / 3) ==
+    @test MetricTensor(a, b, c, 90, 90, 120) ==
           MetricTensor([a^2 -a^2/2 0; -a^2/2 a^2 0; 0 0 c^2])  # Primitive hexagonal
 end


### PR DESCRIPTION
Closes #50