### PR TITLE
Deprecate `one` & `oneunit` for `SeitzOperator`s

### DIFF
--- a/src/Symmetry/Symmetry.jl
+++ b/src/Symmetry/Symmetry.jl
@@ -95,16 +95,6 @@ function Base.inv(op::SeitzOperator)
     return SeitzOperator(𝐑⁻¹, -𝐑⁻¹ * 𝐭)
 end
 
-# See https://github.com/JuliaLang/julia/blob/v1.10.0-beta1/stdlib/LinearAlgebra/src/uniformscaling.jl#L130-L131
-Base.one(::Type{SeitzOperator{T}}) where {T} =
-    SeitzOperator(MMatrix{4,4}(Diagonal(fill(one(T), 4))))
-Base.one(op::SeitzOperator) = one(typeof(op))
-
-# See https://github.com/JuliaLang/julia/blob/v1.10.0-beta1/stdlib/LinearAlgebra/src/uniformscaling.jl#L132-L133
-Base.oneunit(::Type{SeitzOperator{T}}) where {T} =
-    SeitzOperator(MMatrix{4,4}(Diagonal(fill(oneunit(T), 4))))
-Base.oneunit(op::SeitzOperator) = oneunit(typeof(op))
-
 # See https://github.com/JuliaArrays/StaticArraysCore.jl/blob/v1.4.2/src/StaticArraysCore.jl#L397-L398
 struct SeitzOperatorStyle <: Broadcast.AbstractArrayStyle{2} end
 SeitzOperatorStyle(::Val{N}) where {N} = SeitzOperatorStyle()


### PR DESCRIPTION
Since they are even slower than default methods